### PR TITLE
COR, PBEAM, and IBEAM header updates

### DIFF
--- a/pipeline/lwa352_pipeline/blocks/beamform_output_block.py
+++ b/pipeline/lwa352_pipeline/blocks/beamform_output_block.py
@@ -215,11 +215,12 @@ class BeamformOutput(Block):
 
     def __init__(self, log, iring,
                  guarantee=True, core=-1, etcd_client=None, dest_port=10000,
-                 ntime_gulp=480,
+                 ntime_gulp=480, pipeline_idx=0
                  ):
         super(BeamformOutput, self).__init__(log, iring, None, guarantee, core, etcd_client=etcd_client)
 
         self.ntime_gulp = ntime_gulp
+        self.pipeline_idx = pipeline_idx
         self.define_command_key('dest_ip', type=list, initial_val=['0.0.0.0'])
         self.define_command_key('dest_port', type=list, initial_val=[dest_port])
         self.update_command_vals()
@@ -279,10 +280,10 @@ class BeamformOutput(Block):
                         socks[beam].close()
                         socks[beam].connect(Address(ip, port))
                     desc.set_chan0(chan0)
-                    desc.set_tuning(0)
+                    desc.set_tuning(self.pipeline_idx)
                     desc.set_nchan(nchan)
                     desc.set_decimation(upstream_acc_len) # Sets navg field
-                    desc.set_nsrc(nbeam * npipeline)
+                    desc.set_nsrc(npipeline)
                     self.stats.update({'dest_ip': self.command_vals['dest_ip'],
                                        'dest_port': self.command_vals['dest_port'],
                                        'update_pending': self.update_pending,

--- a/pipeline/lwa352_pipeline/blocks/beamform_output_block.py
+++ b/pipeline/lwa352_pipeline/blocks/beamform_output_block.py
@@ -215,7 +215,7 @@ class BeamformOutput(Block):
 
     def __init__(self, log, iring,
                  guarantee=True, core=-1, etcd_client=None, dest_port=10000,
-                 ntime_gulp=480, pipeline_idx=0
+                 ntime_gulp=480, pipeline_idx=1
                  ):
         super(BeamformOutput, self).__init__(log, iring, None, guarantee, core, etcd_client=etcd_client)
 

--- a/pipeline/lwa352_pipeline/blocks/beamform_vlbi_output_block.py
+++ b/pipeline/lwa352_pipeline/blocks/beamform_vlbi_output_block.py
@@ -187,7 +187,7 @@ class BeamformVlbiOutput(Block):
 
     def __init__(self, log, iring,
                  guarantee=True, core=-1, etcd_client=None, dest_port=10000,
-                 ntime_gulp=480,
+                 ntime_gulp=480, pipeline_idx=0
                  ):
         super(BeamformVlbiOutput, self).__init__(log, iring, None, guarantee, core, etcd_client=etcd_client)
         cpu_affinity.set_core(self.core)
@@ -197,6 +197,7 @@ class BeamformVlbiOutput(Block):
         self.define_command_key('dest_port', type=int, initial_val=dest_port)
         self.update_command_vals()
         self.ntime_gulp = ntime_gulp
+        self.pipeline_idx = pipeline_idx
         self.nbeam_send = 1
         self.npol = 2 # If the upstream beamformer provides single pol data, we interpret pairs of beams as dual-pol
 
@@ -223,7 +224,7 @@ class BeamformVlbiOutput(Block):
             desc.set_nchan(system_nchan)
             desc.set_chan0(chan0)
             desc.set_nsrc(system_nchan // nchan)
-            desc.set_tuning(0)
+            desc.set_tuning(self.pipeline_idx)
             for ispan in iseq.read(igulp_size):
                 if ispan.size < igulp_size:
                     continue # ignore final gulp

--- a/pipeline/lwa352_pipeline/blocks/beamform_vlbi_output_block.py
+++ b/pipeline/lwa352_pipeline/blocks/beamform_vlbi_output_block.py
@@ -187,7 +187,7 @@ class BeamformVlbiOutput(Block):
 
     def __init__(self, log, iring,
                  guarantee=True, core=-1, etcd_client=None, dest_port=10000,
-                 ntime_gulp=480, pipeline_idx=0
+                 ntime_gulp=480, pipeline_idx=1
                  ):
         super(BeamformVlbiOutput, self).__init__(log, iring, None, guarantee, core, etcd_client=etcd_client)
         cpu_affinity.set_core(self.core)

--- a/pipeline/lwa352_pipeline/blocks/corr_output_full_block.py
+++ b/pipeline/lwa352_pipeline/blocks/corr_output_full_block.py
@@ -363,7 +363,7 @@ class CorrOutputFull(Block):
     def __init__(self, log, iring,
                  guarantee=True, core=-1, nchan=192, npol=2, nstand=352, etcd_client=None, dest_port=10000,
                  checkfile=None, checkfile_acc_len=1, antpol_to_bl=None, bl_is_conj=None, use_cor_fmt=True,
-                 nchan_sum=1, pipeline_idx=0, npipeline=1):
+                 nchan_sum=1, pipeline_idx=1, npipeline=1):
         # TODO: Other things we could check:
         # - that nchan/pols/gulp_size matches XGPU compilation
         super(CorrOutputFull, self).__init__(log, iring, None, guarantee, core, etcd_client=etcd_client)

--- a/pipeline/lwa352_pipeline/blocks/corr_output_full_block.py
+++ b/pipeline/lwa352_pipeline/blocks/corr_output_full_block.py
@@ -373,6 +373,9 @@ class CorrOutputFull(Block):
         self.npol = npol
         self.nstand = nstand
         self.matlen = nchan * (nstand//2+1)*(nstand//4)*npol*npol*4
+        
+        # Do this now since it doesn't change after the block is initialized
+        self.tuning = (1 << 16) | (self.npipeline << 8) | (self.pipeline_idx % self.npipeline)
 
         self.igulp_size = self.matlen * 8 # complex64
 
@@ -490,7 +493,7 @@ class CorrOutputFull(Block):
         desc.set_gain(gain)
         desc.set_decimation(navg)
         desc.set_nsrc((self.nstand*(self.nstand + 1))//2)
-        desc.set_tuning((1 << 16) | (self.npipeline << 8) | (self.pipeline_idx % self.npipeline))
+        desc.set_tuning(self.tuning)
         pkt_payload_bits = self.nchan * self.npol * self.npol * 8 * 8
         block_bits_sent = 0
         start_time = time.time()

--- a/pipeline/lwa352_pipeline/blocks/corr_output_full_block.py
+++ b/pipeline/lwa352_pipeline/blocks/corr_output_full_block.py
@@ -363,10 +363,11 @@ class CorrOutputFull(Block):
     def __init__(self, log, iring,
                  guarantee=True, core=-1, nchan=192, npol=2, nstand=352, etcd_client=None, dest_port=10000,
                  checkfile=None, checkfile_acc_len=1, antpol_to_bl=None, bl_is_conj=None, use_cor_fmt=True,
-                 pipeline_idx=0, npipeline=1):
+                 nchan_sum=1, pipeline_idx=0, npipeline=1):
         # TODO: Other things we could check:
         # - that nchan/pols/gulp_size matches XGPU compilation
         super(CorrOutputFull, self).__init__(log, iring, None, guarantee, core, etcd_client=etcd_client)
+        self.nchan_sum = nchan_sum
         self.pipeline_idx = pipeline_idx
         self.npipeline = npipeline
         self.nchan = nchan
@@ -375,7 +376,8 @@ class CorrOutputFull(Block):
         self.matlen = nchan * (nstand//2+1)*(nstand//4)*npol*npol*4
         
         # Do this now since it doesn't change after the block is initialized
-        self.tuning = (1 << 16) | (self.npipeline << 8) | (self.pipeline_idx % self.npipeline)
+        self.tuning = (self.nchan_sum << 16) | (self.npipeline << 8) | (self.pipeline_idx % self.npipeline)
+        self.tuning &= 0x00FFFFFF
 
         self.igulp_size = self.matlen * 8 # complex64
 

--- a/pipeline/lwa352_pipeline/blocks/corr_output_part_block.py
+++ b/pipeline/lwa352_pipeline/blocks/corr_output_part_block.py
@@ -327,6 +327,9 @@ class CorrOutputPart(Block):
         self.pipeline_idx = pipeline_idx
         self.npipeline = npipeline
 
+        # Do this now since it doesn't change after the block is initialized
+        self.tuning = (self.nchan_sum << 16) | (self.npipeline << 8) | (self.pipeline_idx % self.npipeline)
+
         self.use_cor_fmt = use_cor_fmt
         if self.use_cor_fmt:
             self.sock = None
@@ -368,7 +371,7 @@ class CorrOutputPart(Block):
         nvis = len(baselines)
         desc.set_nsrc(nvis // nvis_per_pkt)
         nstand_virt = int((-1 + np.sqrt(1 + 2*nvis))/2) # effective number of stands
-        desc.set_tuning((self.nchan_sum << 16) | (self.npipeline << 8) | (self.pipeline_idx % self.npipeline))
+        desc.set_tuning(self.tuning)
         pkt_payload_bits = nchan * nvis_per_pkt * 8 * 8
         start_time = time.time()
         dview = data.view('cf32').reshape([nchan, nvis // nvis_per_pkt, COR_NPOL, COR_NPOL])

--- a/pipeline/lwa352_pipeline/blocks/corr_output_part_block.py
+++ b/pipeline/lwa352_pipeline/blocks/corr_output_part_block.py
@@ -186,7 +186,14 @@ class CorrOutputPart(Block):
         | id            | uint8      |                | Mark 5C ID, used to identify COR packet,    |
         |               |            |                | ``0x02``                                    |
         +---------------+------------+----------------+---------------------------------------------+
-        | frame_number  | uint24     |                | Mark 5C frame number. Unused.               |
+        | frame_number  | uint24     |                | Mark 5C frame number.  Used to store info.  |
+        |               |            |                | about how to order the output packets.  The |
+        |               |            |                | first 8 bits contain the channel decimation |
+        |               |            |                | fraction relative to the F-Engine output.   |
+        |               |            |                | The next 8 bits contain the total number of |
+        |               |            |                | subbands being transmitted.  The final 8    |
+        |               |            |                | contain which subband is contained in the   |
+        |               |            |                | packet.                                     |
         +---------------+------------+----------------+---------------------------------------------+
         | secs_count    | uint32     |                | Mark 5C seconds since 1970-01-01 00:00:00   |
         |               |            |                | UTC. Unused.                                |
@@ -309,12 +316,15 @@ class CorrOutputPart(Block):
     """
 
     def __init__(self, log, iring, use_cor_fmt=False,
-                 guarantee=True, core=-1, etcd_client=None, dest_port=10001, nvis_per_packet=16, npipeline=1):
+                 guarantee=True, core=-1, etcd_client=None, dest_port=10001, nvis_per_packet=16, 
+                 nchan_sum=1, pipeline_idx=0, npipeline=1):
         # TODO: Other things we could check:
         # - that nchan/pols/gulp_size matches XGPU compilation
         super(CorrOutputPart, self).__init__(log, iring, None, guarantee, core, etcd_client=etcd_client)
 
         self.nvis_per_packet = nvis_per_packet
+        self.nchan_sum = nchan_sum
+        self.pipeline_idx = pipeline_idx
         self.npipeline = npipeline
 
         self.use_cor_fmt = use_cor_fmt
@@ -348,7 +358,7 @@ class CorrOutputPart(Block):
             self.sock.sendto(header + dout[vn*self.nvis_per_packet : (vn+1)*self.nvis_per_packet].tobytes(),
                                              (self.command_vals['dest_ip'], self.command_vals['dest_port']))
 
-    def send_packets_bf(self, data, baselines, udt, time_tag, desc, chan0, nchan, gain, navg, tuning):
+    def send_packets_bf(self, data, baselines, udt, time_tag, desc, chan0, nchan, gain, navg):
         cpu_affinity.set_core(self.core)
         start_time = time.time()
         desc.set_chan0(chan0)
@@ -358,7 +368,7 @@ class CorrOutputPart(Block):
         nvis = len(baselines)
         desc.set_nsrc(nvis // nvis_per_pkt)
         nstand_virt = int((-1 + np.sqrt(1 + 2*nvis))/2) # effective number of stands
-        desc.set_tuning(tuning)
+        desc.set_tuning((self.nchan_sum << 16) | (self.npipeline << 8) | (self.pipeline_idx % self.npipeline))
         pkt_payload_bits = nchan * nvis_per_pkt * 8 * 8
         start_time = time.time()
         dview = data.view('cf32').reshape([nchan, nvis // nvis_per_pkt, COR_NPOL, COR_NPOL])
@@ -410,7 +420,6 @@ class CorrOutputPart(Block):
                 sfreq = ihdr['sfreq']
             if self.use_cor_fmt:
                 samples_per_spectra = int(nchan_sum * nchan * ihdr['fs_hz'] / bw_hz)
-                this_pipeline = (chan0 // nchan) % self.npipeline
             igulp_size = nvis * nchan * 8
             dout = np.zeros(shape=[nvis, nchan, 2], dtype='>i')
             for ispan in iseq.read(igulp_size):
@@ -440,7 +449,7 @@ class CorrOutputPart(Block):
                         # Read chan x baseline x complexity input data.
                         idata = ispan.data_view('i32').reshape([nchan, nvis, 2])
                         self.send_packets_bf(idata, baselines, udt, time_tag, desc, chan0, nchan, 0,
-                                upstream_acc_len, (self.npipeline<<8) + (this_pipeline+1))
+                                upstream_acc_len)
                     else:
                         # Read chan x baseline x complexity input data.
                         # Transpose to baseline x chan x complexity

--- a/pipeline/lwa352_pipeline/blocks/corr_output_part_block.py
+++ b/pipeline/lwa352_pipeline/blocks/corr_output_part_block.py
@@ -329,7 +329,8 @@ class CorrOutputPart(Block):
 
         # Do this now since it doesn't change after the block is initialized
         self.tuning = (self.nchan_sum << 16) | (self.npipeline << 8) | (self.pipeline_idx % self.npipeline)
-
+        self.tuning &= 0x00FFFFFF
+        
         self.use_cor_fmt = use_cor_fmt
         if self.use_cor_fmt:
             self.sock = None

--- a/pipeline/lwa352_pipeline/blocks/corr_output_part_block.py
+++ b/pipeline/lwa352_pipeline/blocks/corr_output_part_block.py
@@ -317,7 +317,7 @@ class CorrOutputPart(Block):
 
     def __init__(self, log, iring, use_cor_fmt=False,
                  guarantee=True, core=-1, etcd_client=None, dest_port=10001, nvis_per_packet=16, 
-                 nchan_sum=1, pipeline_idx=0, npipeline=1):
+                 nchan_sum=1, pipeline_idx=1, npipeline=1):
         # TODO: Other things we could check:
         # - that nchan/pols/gulp_size matches XGPU compilation
         super(CorrOutputPart, self).__init__(log, iring, None, guarantee, core, etcd_client=etcd_client)

--- a/pipeline/scripts/lwa352-pipeline.py
+++ b/pipeline/scripts/lwa352-pipeline.py
@@ -108,9 +108,11 @@ def build_pipeline(args):
         server_idx = hostname.split('.', 1)[0].replace('lxdlwagpu', '')
         server_idx = int(server_idx, 10)
     except (AttributeError, ValueError):
-        server_idx = 0 # HACK to allow testing on head node "adp"
+        server_idx = 1 # HACK to allow testing on head node "adp"
+    pipeline_idx = 4*(server_idx - 1) + args.pipelineid + 1
     log.info("Hostname:     %s", hostname)
     log.info("Server index: %i", server_idx)
+    log.info("Pipeline index: %i", pipeline_idx)
     
     if not args.nogpu:
         capture_ring = Ring(name="capture", space='system')
@@ -148,8 +150,6 @@ def build_pipeline(args):
     assert ((NET_NGULP*NETGSIZE) % GSIZE == 0), "GSIZE must be a multiple of NETGSIZE*NET_NGULP"
 
     cores = CoreList(map(int, args.cores.split(',')))
-    
-    pipeline_idx = 4*(server_idx - 1) + args.pipelineid + 1
     
     nfreqblocks = nchan // CHAN_PER_PACKET
     if not args.fakesource:


### PR DESCRIPTION
This PR updates the COR, PBEAM, and IBEAM packet headers to help the data recorders correctly re-order the data.  This is done through:
 * A new `pipeline_idx` value that is is computed from the hostname.
 * Fixes to the COR header to use the `pipeline_idx` value and to encode the channel decimation value.
 * Updates to the COR header format documentation to reflect how `frame_number` is used to encode the packet re-ordering information.
 * Fixes to the PBEAM/IBEAM headers to use the `pipeline_idx` value.