### PR TITLE
COR header off-by-one error

### DIFF
--- a/pipeline/lwa352_pipeline/blocks/corr_output_full_block.py
+++ b/pipeline/lwa352_pipeline/blocks/corr_output_full_block.py
@@ -376,7 +376,8 @@ class CorrOutputFull(Block):
         self.matlen = nchan * (nstand//2+1)*(nstand//4)*npol*npol*4
         
         # Do this now since it doesn't change after the block is initialized
-        self.tuning = (self.nchan_sum << 16) | (self.npipeline << 8) | (self.pipeline_idx % self.npipeline)
+        wrapped_idx = ((self.pipeline_idx - 1) % self.npipeline) + 1
+        self.tuning = (self.nchan_sum << 16) | (self.npipeline << 8) | wrapped_idx
         self.tuning &= 0x00FFFFFF
 
         self.igulp_size = self.matlen * 8 # complex64

--- a/pipeline/lwa352_pipeline/blocks/corr_output_part_block.py
+++ b/pipeline/lwa352_pipeline/blocks/corr_output_part_block.py
@@ -328,7 +328,8 @@ class CorrOutputPart(Block):
         self.npipeline = npipeline
 
         # Do this now since it doesn't change after the block is initialized
-        self.tuning = (self.nchan_sum << 16) | (self.npipeline << 8) | (self.pipeline_idx % self.npipeline)
+        wrapped_idx = ((self.pipeline_idx - 1) % self.npipeline) + 1
+        self.tuning = (self.nchan_sum << 16) | (self.npipeline << 8) | wrapped_idx
         self.tuning &= 0x00FFFFFF
         
         self.use_cor_fmt = use_cor_fmt


### PR DESCRIPTION
This PR fixes an off-by-one error and a wrapping problem in the COR output headers.