### PR TITLE
Beam startup packet loss

### DIFF
--- a/pipeline/lwa352_pipeline/blocks/beamform_sum_beams_block.py
+++ b/pipeline/lwa352_pipeline/blocks/beamform_sum_beams_block.py
@@ -223,7 +223,7 @@ class BeamformSumBeams(Block):
                 # The output gulp size can be quite small if we base it on the input gulp size
                 # force the numper of times in the output span to match the input, which
                 # is likely to be more reasonable
-                self.oring.resize(ogulp_size // self.ntime_blocks * self.ntime_gulp * 4)
+                self.oring.resize(ogulp_size * self.ntime_sum * 4)
                 
                 prev_time = time.time()
                 with oring.begin_sequence(time_tag=iseq.time_tag, header=ohdr_str) as oseq:

--- a/pipeline/lwa352_pipeline/blocks/block_base.py
+++ b/pipeline/lwa352_pipeline/blocks/block_base.py
@@ -157,6 +157,7 @@ class Block(object):
         self._pending_command_vals = {}
         self._command_types = {}
         self._command_conditions = {}
+        self._etcd_sets_pending = True # Set the update_pending attribute to True when etcd callback runs
 
     def define_command_key(self, name, type=None, condition=None, initial_val=None): 
         """
@@ -246,7 +247,7 @@ class Block(object):
                 self._send_command_response(seq_id, False, "`val[kwargs]` field should be a dictionary")
                 continue
             try:
-                proc_ok = self._process_commands(update_keys)
+                proc_ok = self._process_commands(update_keys, set_pending_flag=self._etcd_sets_pending)
             except:
                 proc_ok = COMMAND_INVALID
             self.update_stats({'last_cmd_response':proc_ok})

--- a/pipeline/scripts/lwa352-pipeline.py
+++ b/pipeline/scripts/lwa352-pipeline.py
@@ -248,7 +248,8 @@ def build_pipeline(args):
                               nchan=nchan, core=cores[0], guarantee=True, gpu=args.gpu, ntime_sum=BEAM_TIME_SUM))
 
         ops.append(BeamformOutput(log, iring=bf_power_output_ring, core=cores[0], guarantee=True,
-                                  ntime_gulp=GPU_NGULP*GSIZE//BEAM_TIME_SUM, pipeline_idx=pipeline_idx, etcd_client=etcd_client))
+                                  ntime_gulp=GPU_NGULP*GSIZE//BEAM_TIME_SUM, pipeline_idx=pipeline_idx,
+                                  nchan=nchan, nbeam=NBEAM, etcd_client=etcd_client))
 
         cores.pop(0)
         ops.append(BeamformVlbiOutput(log, iring=bf_output_ring, ntime_gulp=GPU_NGULP*GSIZE,


### PR DESCRIPTION
Far from a satisfying fix for an issue where setting the power beam output addresses causes input packet loss.
These commits avoid creating `UDPTransport` (UDPT) instances in the power beamformer output when the pipeline is brought up, and only creates these for the first time when the destinations are set. Empirically, it appears that creating a UDPT is substantially quicker than replacing an existing one with a new instance pointed to a new destination.
I don't fully understand why the destruction of a UDPT seems to have such an impact on the performance of the entirety of bifrost, but it appears to.
These commits also add some strategic sleeps which (maybe) will help alleviate packet loss in the event a user outrageously decides to change their mind about packet destinations after UDPTs have been created.