### PR TITLE
Make sure etcd connection closes.

### DIFF
--- a/pipeline-control/lwa352_pipeline_control/etcd_control.py
+++ b/pipeline-control/lwa352_pipeline_control/etcd_control.py
@@ -362,4 +362,9 @@ class EtcdCorrControl():
         else:
             return val
 
-
+    def close(self):
+        """
+        Close existing etcd connection(s) held by the instance.
+        """
+        if self.ec:
+            self.ec.close()

--- a/pipeline-control/lwa352_pipeline_control/lwa352_pipeline_control.py
+++ b/pipeline-control/lwa352_pipeline_control/lwa352_pipeline_control.py
@@ -346,6 +346,7 @@ class Lwa352PipelineControl():
         self.beamform_output = BeamformOutputControl(*args)
         self.beamform_vlbi_output = BeamformVlbiOutputControl(*args)
         if not self.check_connection():
+            self.corr_interface.close()
             raise RuntimeError("Connection failed. Consider restarting lwa-xeng-etcd.service daemon on host %s" % host)
 
     def start_pipeline(self):


### PR DESCRIPTION
When `self.check_connection()` throws an exception (say a transient DNS resolution failure) in `Lwa352PipelineControl.__init__` , I suspect python doesn't destroy `self.corr_interface`  right away (or at all). In any case I don't think this hurt. This is partially a bandaid solution to https://github.com/ovro-lwa/lwa-issues/issues/248