### PR TITLE
Maintain VLBI packet sender instance across sequencies

### DIFF
--- a/pipeline/lwa352_pipeline/blocks/beamform_vlbi_output_block.py
+++ b/pipeline/lwa352_pipeline/blocks/beamform_vlbi_output_block.py
@@ -210,6 +210,7 @@ class BeamformVlbiOutput(Block):
         self.bind_proclog.update({'ncore': 1, 
                                   'core0': cpu_affinity.get_core(),})
 
+        udt = None
         prev_time = time.time()
         for iseq in self.iring.read(guarantee=self.guarantee):
             self.update_pending = True
@@ -223,7 +224,6 @@ class BeamformVlbiOutput(Block):
             npol  = ihdr['npol']
             igulp_size = self.ntime_gulp * nbeam * nchan * npol * 2 * nbit // 8
             packet_cnt = 0
-            udt = None
             desc = HeaderInfo()
             desc.set_nchan(nchan)
             desc.set_chan0(chan0)


### PR DESCRIPTION
This PR changes where the packet sender instance used for the VLBI beam is initialized to address https://github.com/ovro-lwa/lwa-issues/issues/447.  This is done by moving the packet sender (`udt`) initialization to outside the loop over sequences.